### PR TITLE
Move react-dom from dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "graphiql": "^1.6.0",
     "graphql": "^16.3.0",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react-dom": "^17.0.2"
+  },
+  "devDependencies": {
     "react-scripts": "5.0.0"
   },
   "scripts": {


### PR DESCRIPTION
Suggested on
https://github.com/facebook/create-react-app/issues/11174

This suppresses the false positive reports from snyk.io and dependabot:
https://nvd.nist.gov/vuln/detail/CVE-2021-3803
https://nvd.nist.gov/vuln/detail/CVE-2021-33587